### PR TITLE
USAGE: > preceding the path to the SVG

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -5,7 +5,7 @@ FreeBSD 13.1-STABLE or later for full loader+kernel+rc.d tracing.)
 2. Add 'options TSLOG' to your kernel configuration and `make kernel`.
 
 3. After rebooting, to produce an SVG:
-# sh mkflame.sh tslog.svg
+# sh mkflame.sh > tslog.svg
 
 4. (Optional) To get a list of the top 10 stack leaves:
 # sh tslog.sh > ts.log


### PR DESCRIPTION
Without > , a large amount of XML is printed to the screen (not written to the file).