### PR TITLE
Make the scripts NetBSD-compatible

### DIFF
--- a/mkflame.sh
+++ b/mkflame.sh
@@ -8,7 +8,7 @@ fi
 
 TSCEND=`sysctl -n debug.tslog_user | grep sh | head -1 | cut -f 4 -d ' '`
 case `uname -p` in
-amd64)
+amd64|x86_64)
 	TSCFREQ=`sysctl -n machdep.tsc_freq`
 	;;
 aarch64)
@@ -27,4 +27,4 @@ sh tslog.sh |
     perl flamechart.pl -flamechart -colors tslog --hash \
 	--title "`uname -r | cut -f 1-2 -d -` boot" \
 	--subtitle "$MS ms" \
-	--width $((MS / SCALE))
+	--width $(echo "$MS / $SCALE"|bc)

--- a/mkflame.sh
+++ b/mkflame.sh
@@ -27,4 +27,4 @@ sh tslog.sh |
     perl flamechart.pl -flamechart -colors tslog --hash \
 	--title "`uname -r | cut -f 1-2 -d -` boot" \
 	--subtitle "$MS ms" \
-	--width $(echo "$MS / $SCALE"|bc)
+	--width $(echo "$MS / $SCALE" | bc)


### PR DESCRIPTION
A few modifications were necessary in order to make these scripts compatible with NetBSD port of `tslog` https://github.com/NetBSD/src/commit/78e5ba0ad7287f7560d0e658aa035a43f08db30c
Also, with fast boots, the scaling needs to be < 1, so instead of shell arithmetic, I simply piped `MS / SCALE` to `bc`.